### PR TITLE
Fix Heroku Deploy static files issue

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,15 +19,26 @@ process.env.PWD = process.cwd()
 
 knex.migrate.latest([config]);
 
+STATICFILES = path.join(process.env.PWD, 'bower_components');
 
-
+/* These are a hot fix for our directories that are mixed case*/
+//TODO Fix these mixed cased directories
+app.use('/app',express.static(path.join(process.env.PWD,'public','App')));
+app.use('/app/auth',express.static(path.join(process.env.PWD,'public','App','Auth')))
+app.use('/app/categories',express.static(path.join(process.env.PWD,'public','App','Categories')))
+app.use('/app/results',express.static(path.join(process.env.PWD,'public','App','Results')))
+app.use('/app/subcategories',express.static(path.join(process.env.PWD,'public','App','Subcategories')))
+/*HOTFIX END*/
 // view engine setup
-
 app.get('/', function(req,res){
   res.sendFile(path.join(process.env.PWD, 'public','index.html'))
 });
-app.use('/scripts', express.static('bower_components'));
-app.use(express.static('public'));
+
+app.use(express.static(path.join(process.env.PWD,'public')));
+app.use('/scripts', express.static(STATICFILES));
+
+
+
 
 // uncomment after placing your favicon in /public
 //app.use(favicon(path.join(process.env.PWD, 'public', 'favicon.ico')));
@@ -54,7 +65,7 @@ app.use(session({
     })
   }));
 
-app.use('/', routes);
+// app.use('/', routes);
 app.use('/api', api);
 
 

--- a/package.json
+++ b/package.json
@@ -3,10 +3,12 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "start": "nodemon ./bin/www"
+    "start": "nodemon ./bin/www",
+    "postinstall": "./node_modules/bower/bin/bower install"
   },
   "engines": {
-    "node": ">= 0.10.0"
+    "node": "0.10.33",
+    "npm": "2.11.3"
   },
   "devDependencies": {
     "grunt": "~0.4.5",
@@ -19,6 +21,7 @@
   "dependencies": {
     "bcrypt-nodejs": "0.0.3",
     "body-parser": "~1.13.2",
+    "bower": "^1.4.1",
     "connect-pg-simple": "^3.0.1",
     "cookie-parser": "~1.3.5",
     "debug": "~2.2.0",


### PR DESCRIPTION
This is the official fix for our static files bug on Heroku. For those interested here are the solutions:
- Bower was never run on heroku, so all of our /static file directory never existed
  - Solution was to install bower as a dependency on package.json
  - Run bower as a post install script
- Some of our directories have Uppercase names (i.e /public/app/Auth), this breaks express static file serve, brought this up on issue #61

This hotfixes issue number #59 
